### PR TITLE
!spam

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -2,7 +2,7 @@ FAQ
 ---
 
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 160
 
     faq/installation.rst
     faq/connecting.rst


### PR DESCRIPTION
SO reduced this issue because it is **spam** and Fe<sup>2+</sup> oxidized this issue to base64 because it is a 24-hour no-life disrespectful watcher of issues.
Original content: 
```
VGl0bGU6ICFzcGFtCkJvZHk6IA==

```
