### PR TITLE
fix: resolve sphinx build warnings (underlines and duplicate targets)

### DIFF
--- a/source/developers/internals-docs/adding-vanilla-blocks.rst
+++ b/source/developers/internals-docs/adding-vanilla-blocks.rst
@@ -80,7 +80,7 @@ Some common ones include:
 +---------------------------------+-------------------------------------------------------------------------------------------------------+--------------------------------------------------------+
 
 2) Register your block in ``src/block/VanillaBlocksInputs.php``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This will create a ``VanillaBlocks::YOUR_BLOCK()`` static method
 automagically. In here, you’ll define properties like:

--- a/source/installation/installing-manually.rst
+++ b/source/installation/installing-manually.rst
@@ -11,10 +11,10 @@ Windows
 ~~~~~~~
 
 1. Make a folder for your server. If you're updating an existing server, delete ``PocketMine-MP.phar``, any file called ``start``, and the ``bin`` folder from the folder.
-2. Download the custom PHP binary for Windows `here <https://github.com/pmmp/PHP-Binaries/releases>`_. **Make sure you get the right version for your chosen version of PocketMine-MP** (see below).
+2. Download the custom PHP binary for Windows `here <https://github.com/pmmp/PHP-Binaries/releases>`__. **Make sure you get the right version for your chosen version of PocketMine-MP** (see below).
 3. Right-click -> click Extract All, pick your server folder and click Extract. Now you should have a folder called ``bin``.
 4. In the ``bin`` folder, double-click the file ``vc_redist.x64.exe``, accept the terms and conditions, and install. This will install Microsoft Visual C++ Redistributable, which is needed by the PHP binary.
-5. Download your chosen version of ``PocketMine-MP.phar`` and ``start.cmd`` from `here <https://github.com/pmmp/PocketMine-MP/releases>`_ and save them in your server folder.
+5. Download your chosen version of ``PocketMine-MP.phar`` and ``start.cmd`` from `here <https://github.com/pmmp/PocketMine-MP/releases>`__ and save them in your server folder.
 
 Now you should be able to double-click ``start.cmd`` to start the server.
 
@@ -27,9 +27,9 @@ The following steps require you to use the Terminal.
 1. ``cd`` to wherever you want to put the server (e.g. ``cd /home/dylan``).
 2. Make a folder for your server using ``mkdir`` (e.g. ``mkdir pocketmine``). If you're updating an existing server, ``cd`` directly to your server's folder instead.
 3. Run ``rm -rf ./bin ./PocketMine-MP.phar ./start.sh``. This deletes any outdated server files (don't worry, your data won't be harmed).
-4. Find the download link for the right PHP version for your OS. You can see a list of available ones `here <https://github.com/pmmp/PHP-Binaries/releases>`_.
+4. Find the download link for the right PHP version for your OS. You can see a list of available ones `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
 5. Run ``curl -L <link to your chosen PHP binary> | tar -xz``. Now you should have a folder called ``bin``. **Make sure you get the right version for your chosen version of PocketMine-MP** (see below).
-6. Find the download link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` `here <https://github.com/pmmp/PocketMine-MP/releases>`_.
+6. Find the download link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
 7. Run ``curl -LO <link to PocketMine-MP.phar>``.
 8. Run ``curl -LO <link to start.sh>``.
 9. Run ``chmod +x ./start.sh``.`

--- a/source/installation/installing-manually.rst
+++ b/source/installation/installing-manually.rst
@@ -29,7 +29,7 @@ The following steps require you to use the Terminal.
 3. Run ``rm -rf ./bin ./PocketMine-MP.phar ./start.sh``. This deletes any outdated server files (don't worry, your data won't be harmed).
 4. Find the download link for the right PHP version for your OS. You can see a list of available ones from `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
 5. Run ``curl -L <link to your chosen PHP binary> | tar -xz``. Now you should have a folder called ``bin``. **Make sure you get the right version for your chosen version of PocketMine-MP** (see below).
-6. Find the download from link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` from `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
+6. Find the download link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` from `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
 7. Run ``curl -LO <link to PocketMine-MP.phar>``.
 8. Run ``curl -LO <link to start.sh>``.
 9. Run ``chmod +x ./start.sh``.

--- a/source/installation/installing-manually.rst
+++ b/source/installation/installing-manually.rst
@@ -27,9 +27,9 @@ The following steps require you to use the Terminal.
 1. ``cd`` to wherever you want to put the server (e.g. ``cd /home/dylan``).
 2. Make a folder for your server using ``mkdir`` (e.g. ``mkdir pocketmine``). If you're updating an existing server, ``cd`` directly to your server's folder instead.
 3. Run ``rm -rf ./bin ./PocketMine-MP.phar ./start.sh``. This deletes any outdated server files (don't worry, your data won't be harmed).
-4. Find the download from link for the right PHP version for your OS. You can see a list of available ones `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
+4. Find the download link for the right PHP version for your OS. You can see a list of available ones from `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
 5. Run ``curl -L <link to your chosen PHP binary> | tar -xz``. Now you should have a folder called ``bin``. **Make sure you get the right version for your chosen version of PocketMine-MP** (see below).
-6. Find the download from link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
+6. Find the download from link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` from `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
 7. Run ``curl -LO <link to PocketMine-MP.phar>``.
 8. Run ``curl -LO <link to start.sh>``.
 9. Run ``chmod +x ./start.sh``.

--- a/source/installation/installing-manually.rst
+++ b/source/installation/installing-manually.rst
@@ -27,9 +27,9 @@ The following steps require you to use the Terminal.
 1. ``cd`` to wherever you want to put the server (e.g. ``cd /home/dylan``).
 2. Make a folder for your server using ``mkdir`` (e.g. ``mkdir pocketmine``). If you're updating an existing server, ``cd`` directly to your server's folder instead.
 3. Run ``rm -rf ./bin ./PocketMine-MP.phar ./start.sh``. This deletes any outdated server files (don't worry, your data won't be harmed).
-4. Find the download link for the right PHP version for your OS. You can see a list of available ones `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
+4. Find the download from link for the right PHP version for your OS. You can see a list of available ones `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
 5. Run ``curl -L <link to your chosen PHP binary> | tar -xz``. Now you should have a folder called ``bin``. **Make sure you get the right version for your chosen version of PocketMine-MP** (see below).
-6. Find the download link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
+6. Find the download from link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
 7. Run ``curl -LO <link to PocketMine-MP.phar>``.
 8. Run ``curl -LO <link to start.sh>``.
 9. Run ``chmod +x ./start.sh``.

--- a/source/installation/installing-manually.rst
+++ b/source/installation/installing-manually.rst
@@ -27,9 +27,9 @@ The following steps require you to use the Terminal.
 1. ``cd`` to wherever you want to put the server (e.g. ``cd /home/dylan``).
 2. Make a folder for your server using ``mkdir`` (e.g. ``mkdir pocketmine``). If you're updating an existing server, ``cd`` directly to your server's folder instead.
 3. Run ``rm -rf ./bin ./PocketMine-MP.phar ./start.sh``. This deletes any outdated server files (don't worry, your data won't be harmed).
-4. Find the download link for the right PHP version for your OS. You can see a list of available ones from `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
+4. Find the download link for the right PHP version for your OS. You can see a list of available ones `here <https://github.com/pmmp/PHP-Binaries/releases>`__.
 5. Run ``curl -L <link to your chosen PHP binary> | tar -xz``. Now you should have a folder called ``bin``. **Make sure you get the right version for your chosen version of PocketMine-MP** (see below).
-6. Find the download link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` from `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
+6. Find the download link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
 7. Run ``curl -LO <link to PocketMine-MP.phar>``.
 8. Run ``curl -LO <link to start.sh>``.
 9. Run ``chmod +x ./start.sh``.

--- a/source/installation/installing-manually.rst
+++ b/source/installation/installing-manually.rst
@@ -32,7 +32,7 @@ The following steps require you to use the Terminal.
 6. Find the download link for your chosen version of ``PocketMine-MP.phar`` and ``start.sh`` `here <https://github.com/pmmp/PocketMine-MP/releases>`__.
 7. Run ``curl -LO <link to PocketMine-MP.phar>``.
 8. Run ``curl -LO <link to start.sh>``.
-9. Run ``chmod +x ./start.sh``.`
+9. Run ``chmod +x ./start.sh``.
 
 Now you should be able to run the server by running ``./start.sh``.
 


### PR DESCRIPTION
### Summary
This PR addresses and resolves all Sphinx build warnings currently present in the project. These fixes ensure a cleaner build process and prevent potential rendering issues in the documentation.

### Changes Made:
1.  **Fixed Title Underlines:** In `source/developers/internals-docs/adding-vanilla-blocks.rst`, adjusted the underline lengths to match the section titles (fixed "Title underline too short" warnings).
2.  **Resolved Duplicate Targets:** In `source/installation/installing-manually.rst`, converted repetitive link targets (using the word "here") to **anonymous hyperlinks** (`__`) to resolve "Duplicate explicit target name" warnings.

### Motivation:
Keeping the documentation build free of warnings is essential for maintaining code health and ensuring that any new actual errors are not buried under a pile of formatting warnings.

### Verification:
I have verified the changes locally by running `make html`. The build now completes successfully with **zero warnings**.

### Related Issue
Fixes #42 